### PR TITLE
Use namespace-less XPath selectors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/.project

--- a/camt2csv.xsl
+++ b/camt2csv.xsl
@@ -1,26 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright (C) 2012, Daniel Pocock http://danielpocock.com -->
 <xsl:stylesheet version="1.0"
-    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-    xmlns:camt="urn:iso:std:iso:20022:tech:xsd:camt.053.001.02">
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 <xsl:output method="text" encoding="UTF-8"/>
 
 <xsl:strip-space elements="*" />
 
-<xsl:template match="/camt:Document/camt:BkToCstmrStmt/camt:GrpHdr">
-  <xsl:if test="camt:MsgPgntn/camt:PgNb != 1 or camt:MsgPgntn/camt:LastPgInd != 'true'">
+<xsl:template match="/*[local-name() = 'Document']/*[local-name() = 'BkToCstmrStmt']/*[local-name() = 'GrpHdr']">
+  <xsl:if test="*[local-name() = 'MsgPgntn']/*[local-name() = 'PgNb'] != 1 or *[local-name() = 'MsgPgntn']/*[local-name() = 'LastPgInd'] != 'true'">
     <xsl:message terminate="yes">
       <xsl:text>Incomplete message (not first page or subsequent pages exist)</xsl:text>
     </xsl:message>
   </xsl:if>
 </xsl:template>
 
-<xsl:template match="/camt:Document/camt:BkToCstmrStmt/camt:Stmt">
-<xsl:for-each select="camt:Ntry">
-<xsl:value-of select="camt:BookgDt/camt:Dt"/>,<xsl:value-of select="camt:ValDt/camt:Dt"/>,"<xsl:value-of select="camt:AcctSvcrRef"/>","<xsl:value-of select="camt:AddtlNtryInf"/>",<xsl:if test="camt:CdtDbtInd != 'CRDT'">-</xsl:if><xsl:value-of select="camt:Amt"/><xsl:text>&#xD;&#xA;</xsl:text>
+<xsl:template match="/*[local-name() = 'Document']/*[local-name() = 'BkToCstmrStmt']/*[local-name() = 'Stmt']">
+<xsl:for-each select="*[local-name() = 'Ntry']">
+<xsl:value-of select="*[local-name() = 'BookgDt']/*[local-name() = 'Dt']"/>,<xsl:value-of select="*[local-name() = 'ValDt']/*[local-name() = 'Dt']"/>,"<xsl:value-of select="*[local-name() = 'AcctSvcrRef']"/>","<xsl:value-of select="*[local-name() = 'AddtlNtryInf']"/>",<xsl:if test="*[local-name() = 'CdtDbtInd'] != 'CRDT'">-</xsl:if><xsl:value-of select="*[local-name() = 'Amt']"/><xsl:text>&#xD;&#xA;</xsl:text>
 </xsl:for-each>
 </xsl:template>
 
-<xsl:template match="/"><xsl:apply-templates select="/camt:Document/camt:BkToCstmrStmt/camt:GrpHdr|/camt:Document/camt:BkToCstmrStmt/camt:Stmt"/></xsl:template>
+<xsl:template match="/"><xsl:apply-templates select="/*[local-name() = 'Document']/*[local-name() = 'BkToCstmrStmt']/*[local-name() = 'GrpHdr']|/*[local-name() = 'Document']/*[local-name() = 'BkToCstmrStmt']/*[local-name() = 'Stmt']"/></xsl:template>
 
 </xsl:stylesheet>

--- a/camt2csv.xsl
+++ b/camt2csv.xsl
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright (C) 2012, Daniel Pocock http://danielpocock.com -->
 <xsl:stylesheet version="1.0"
-    xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:foo="http://whatever">
 <xsl:output method="text" encoding="UTF-8"/>
 
 <xsl:strip-space elements="*" />
@@ -16,7 +17,39 @@
 
 <xsl:template match="/*[local-name() = 'Document']/*[local-name() = 'BkToCstmrStmt']/*[local-name() = 'Stmt']">
 <xsl:for-each select="*[local-name() = 'Ntry']">
-<xsl:value-of select="*[local-name() = 'BookgDt']/*[local-name() = 'Dt']"/>,<xsl:value-of select="*[local-name() = 'ValDt']/*[local-name() = 'Dt']"/>,"<xsl:value-of select="*[local-name() = 'AcctSvcrRef']"/>","<xsl:value-of select="*[local-name() = 'AddtlNtryInf']"/>",<xsl:if test="*[local-name() = 'CdtDbtInd'] != 'CRDT'">-</xsl:if><xsl:value-of select="*[local-name() = 'Amt']"/><xsl:text>&#xD;&#xA;</xsl:text>
+<xsl:variable name="AddtlNtryInf" select="*[local-name() = 'AddtlNtryInf']" />
+<xsl:variable name="Ustrd" select="*[local-name() = 'NtryDtls']/*[local-name() = 'TxDtls']/*[local-name() = 'RmtInf']/*[local-name() = 'Ustrd']" />
+
+<xsl:variable name="desc1">
+  <xsl:choose>
+    <xsl:when test="$Ustrd = substring($AddtlNtryInf, string-length($AddtlNtryInf) - string-length($Ustrd) +1)"><xsl:value-of select="$AddtlNtryInf"/></xsl:when>
+    <xsl:otherwise><xsl:value-of select="$AddtlNtryInf"/><xsl:text> </xsl:text><xsl:value-of select="$Ustrd"/></xsl:otherwise>
+  </xsl:choose>
+</xsl:variable>
+
+<xsl:variable name="CdtrNm" select="*[local-name() = 'NtryDtls']/*[local-name() = 'TxDtls']/*[local-name() = 'RltdPties']/*[local-name() = 'Cdtr']/*[local-name() = 'Nm']" />
+<xsl:variable name="desc2">
+  <xsl:choose>
+    <xsl:when test="$CdtrNm != 'NOTPROVIDED' and $CdtrNm != 'Peter Palaga'"><xsl:value-of select="$desc1"/><xsl:text> </xsl:text><xsl:value-of select="$CdtrNm"/></xsl:when>
+    <xsl:otherwise><xsl:value-of select="$desc1"/></xsl:otherwise>
+  </xsl:choose>
+</xsl:variable>
+
+<xsl:variable name="DbtrNm" select="*[local-name() = 'NtryDtls']/*[local-name() = 'TxDtls']/*[local-name() = 'RltdPties']/*[local-name() = 'Dbtr']/*[local-name() = 'Nm']" />
+<xsl:variable name="desc3">
+  <xsl:choose>
+    <xsl:when test="$DbtrNm != 'NOTPROVIDED' and $DbtrNm != 'Peter Palaga'"><xsl:value-of select="$desc2"/><xsl:text> </xsl:text><xsl:value-of select="$DbtrNm"/></xsl:when>
+    <xsl:otherwise><xsl:value-of select="$desc2"/></xsl:otherwise>
+  </xsl:choose>
+</xsl:variable>
+
+<xsl:value-of
+    select="*[local-name() = 'BookgDt']/*[local-name() = 'Dt']"/>,<xsl:value-of
+    select="*[local-name() = 'ValDt']/*[local-name() = 'Dt']"/>,"<xsl:value-of
+    select="$desc3"/>",<xsl:if
+    test="*[local-name() = 'CdtDbtInd'] != 'CRDT'">-</xsl:if><xsl:value-of
+    select="*[local-name() = 'Amt']"/>,"<xsl:value-of
+    select="*[local-name() = 'Amt']/@Ccy"/>"<xsl:text>&#xD;&#xA;</xsl:text>
 </xsl:for-each>
 </xsl:template>
 

--- a/camt2pdf.xsl
+++ b/camt2pdf.xsl
@@ -11,19 +11,18 @@
        and for the ISO 20022 sample document use
          xmlns:camt="urn:iso:std:iso:20022:tech:xsd:camt.053.001.04"
   -->
-       
+
 <xsl:stylesheet version="1.0"
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-    xmlns:fo="http://www.w3.org/1999/XSL/Format"
-    xmlns:camt="urn:iso:std:iso:20022:tech:xsd:camt.053.001.02">
+    xmlns:fo="http://www.w3.org/1999/XSL/Format">
   <xsl:output method="xml" encoding="UTF-8"/>
 
   <!-- Look at the file's GrpHdr -->
-  <xsl:template match="/camt:Document/camt:BkToCstmrStmt/camt:GrpHdr">
+  <xsl:template match="/*[local-name() = 'Document']/*[local-name() = 'BkToCstmrStmt']/*[local-name() = 'GrpHdr']">
     <!-- Check if the camt 053 statement is contained within a single file/message
          We don't handle statements split into multiple files yet
          and if one is encountered, the translation will be aborted -->
-    <xsl:if test="camt:MsgPgntn/camt:PgNb != 1 or camt:MsgPgntn/camt:LastPgInd != 'true'">
+    <xsl:if test="*[local-name() = 'MsgPgntn']/*[local-name() = 'PgNb'] != 1 or *[local-name() = 'MsgPgntn']/*[local-name() = 'LastPgInd'] != 'true'">
       <xsl:message terminate="yes">
         <xsl:text>Incomplete message (not first page or subsequent pages exist)</xsl:text>
       </xsl:message>
@@ -31,47 +30,47 @@
   </xsl:template>
 
   <!-- Handle one of the summary rows (opening or closing balance details) -->
-  <xsl:template match="/camt:Document/camt:BkToCstmrStmt/camt:Stmt/camt:Bal">
+  <xsl:template match="/*[local-name() = 'Document']/*[local-name() = 'BkToCstmrStmt']/*[local-name() = 'Stmt']/*[local-name() = 'Bal']">
     <fo:table-row>
       <fo:table-cell>
         <fo:block font-weight="bold">
           <xsl:choose>
-            <xsl:when test="camt:Tp/camt:CdOrPrtry/camt:Cd = 'OPBD'">Opening</xsl:when>
-            <xsl:when test="camt:Tp/camt:CdOrPrtry/camt:Cd = 'CLBD'">Closing</xsl:when>
+            <xsl:when test="*[local-name() = 'Tp']/*[local-name() = 'CdOrPrtry']/*[local-name() = 'Cd'] = 'OPBD'">Opening</xsl:when>
+            <xsl:when test="*[local-name() = 'Tp']/*[local-name() = 'CdOrPrtry']/*[local-name() = 'Cd'] = 'CLBD'">Closing</xsl:when>
             <xsl:otherwise>-</xsl:otherwise>
           </xsl:choose>
         </fo:block>
       </fo:table-cell>
       <fo:table-cell>
         <fo:block>
-          <xsl:value-of select="camt:Dt/camt:Dt"/><xsl:if test="camt:Tp/camt:CdOrPrtry/camt:Cd = 'OPBD'">&#160;(+1)</xsl:if>
+          <xsl:value-of select="*[local-name() = 'Dt']/*[local-name() = 'Dt']"/><xsl:if test="*[local-name() = 'Tp']/*[local-name() = 'CdOrPrtry']/*[local-name() = 'Cd'] = 'OPBD'">&#160;(+1)</xsl:if>
         </fo:block>
       </fo:table-cell>
       <fo:table-cell text-align="right">
-        <fo:block><xsl:if test="camt:CdtDbtInd != 'CRDT'">-</xsl:if><xsl:value-of select="camt:Amt"/></fo:block>
+        <fo:block><xsl:if test="*[local-name() = 'CdtDbtInd'] != 'CRDT'">-</xsl:if><xsl:value-of select="*[local-name() = 'Amt']"/></fo:block>
       </fo:table-cell>
     </fo:table-row>
   </xsl:template>
 
   <!-- Handle one of the entries in the list of transactions -->
-  <xsl:template match="/camt:Document/camt:BkToCstmrStmt/camt:Stmt/camt:Ntry">
+  <xsl:template match="/*[local-name() = 'Document']/*[local-name() = 'BkToCstmrStmt']/*[local-name() = 'Stmt']/*[local-name() = 'Ntry']">
     <fo:table-row>
       <fo:table-cell>
-        <fo:block><xsl:value-of select="camt:BookgDt/camt:Dt"/></fo:block>
+        <fo:block><xsl:value-of select="*[local-name() = 'BookgDt']/*[local-name() = 'Dt']"/></fo:block>
       </fo:table-cell>
       <fo:table-cell>
-        <fo:block><xsl:value-of select="camt:ValDt/camt:Dt"/></fo:block>
+        <fo:block><xsl:value-of select="*[local-name() = 'ValDt']/*[local-name() = 'Dt']"/></fo:block>
       </fo:table-cell>
       <fo:table-cell>
-        <fo:block><xsl:value-of select="camt:AcctSvcrRef"/></fo:block>
-        <fo:block><xsl:value-of select="camt:NtryDtls/camt:TxDtls/camt:RltdPties/camt:*/camt:Nm"/></fo:block>
-        <fo:block><xsl:value-of select="camt:AddtlNtryInf"/></fo:block>
+        <fo:block><xsl:value-of select="*[local-name() = 'AcctSvcrRef']"/></fo:block>
+        <fo:block><xsl:value-of select="*[local-name() = 'NtryDtls']/*[local-name() = 'TxDtls']/*[local-name() = 'RltdPties']/camt:*/*[local-name() = 'Nm']"/></fo:block>
+        <fo:block><xsl:value-of select="*[local-name() = 'AddtlNtryInf']"/></fo:block>
       </fo:table-cell>
       <fo:table-cell text-align="right">
-        <fo:block><xsl:if test="camt:CdtDbtInd = 'CRDT'"><xsl:value-of select="camt:Amt"/></xsl:if></fo:block>
+        <fo:block><xsl:if test="*[local-name() = 'CdtDbtInd'] = 'CRDT'"><xsl:value-of select="*[local-name() = 'Amt']"/></xsl:if></fo:block>
       </fo:table-cell>
       <fo:table-cell text-align="right">
-        <fo:block><xsl:if test="camt:CdtDbtInd = 'DBIT'"><xsl:value-of select="camt:Amt"/></xsl:if></fo:block>
+        <fo:block><xsl:if test="*[local-name() = 'CdtDbtInd'] = 'DBIT'"><xsl:value-of select="*[local-name() = 'Amt']"/></xsl:if></fo:block>
       </fo:table-cell>
     </fo:table-row>
   </xsl:template>
@@ -79,7 +78,7 @@
   <!-- Handle the root node of the XML document -->
   <xsl:template match="/">
     <!-- Check the GrpHdr first -->
-    <xsl:apply-templates select="/camt:Document/camt:BkToCstmrStmt/camt:GrpHdr"/>
+    <xsl:apply-templates select="/*[local-name() = 'Document']/*[local-name() = 'BkToCstmrStmt']/*[local-name() = 'GrpHdr']"/>
 
     <!-- Start generating an XSL-FO document -->
     <fo:root xmlns:fo="http://www.w3.org/1999/XSL/Format">
@@ -105,12 +104,12 @@
         <fo:static-content flow-name="xsl-region-before">
           <fo:block font-size="9pt" font-family="sans-serif">
             <!-- Account number and currency -->
-            <xsl:value-of select="/camt:Document/camt:BkToCstmrStmt/camt:Stmt/camt:Acct/camt:Id"/>
-              (<xsl:value-of select="/camt:Document/camt:BkToCstmrStmt/camt:Stmt/camt:Bal/camt:Amt/@Ccy"/>)
+            <xsl:value-of select="/*[local-name() = 'Document']/*[local-name() = 'BkToCstmrStmt']/*[local-name() = 'Stmt']/*[local-name() = 'Acct']/*[local-name() = 'Id']"/>
+              (<xsl:value-of select="/*[local-name() = 'Document']/*[local-name() = 'BkToCstmrStmt']/*[local-name() = 'Stmt']/*[local-name() = 'Bal']/*[local-name() = 'Amt']/@Ccy"/>)
           </fo:block>
           <fo:block font-size="9pt" font-family="sans-serif">
             <!-- Account holder name -->
-            <xsl:value-of select="/camt:Document/camt:BkToCstmrStmt/camt:Stmt/camt:Acct/camt:Ownr/camt:Nm"/>
+            <xsl:value-of select="/*[local-name() = 'Document']/*[local-name() = 'BkToCstmrStmt']/*[local-name() = 'Stmt']/*[local-name() = 'Acct']/*[local-name() = 'Ownr']/*[local-name() = 'Nm']"/>
           </fo:block>
         </fo:static-content>
 
@@ -123,7 +122,7 @@
         </fo:static-content>
 
         <fo:flow flow-name="xsl-region-body">
- 
+
           <!-- Summary of opening and closing dates and balances -->
           <fo:block font-style="italic" font-size="12pt" font-family="sans-serif">Summary</fo:block>
 
@@ -147,8 +146,8 @@
                 </fo:table-row>
               </fo:table-header>
               <fo:table-body>
-                <xsl:apply-templates select="/camt:Document/camt:BkToCstmrStmt/camt:Stmt/camt:Bal/camt:Tp/camt:CdOrPrtry/camt:Cd[text()='OPBD']/../../.."/>
-                <xsl:apply-templates select="/camt:Document/camt:BkToCstmrStmt/camt:Stmt/camt:Bal/camt:Tp/camt:CdOrPrtry/camt:Cd[text()='CLBD']/../../.."/>
+                <xsl:apply-templates select="/*[local-name() = 'Document']/*[local-name() = 'BkToCstmrStmt']/*[local-name() = 'Stmt']/*[local-name() = 'Bal']/*[local-name() = 'Tp']/*[local-name() = 'CdOrPrtry']/*[local-name() = 'Cd'][text()='OPBD']/../../.."/>
+                <xsl:apply-templates select="/*[local-name() = 'Document']/*[local-name() = 'BkToCstmrStmt']/*[local-name() = 'Stmt']/*[local-name() = 'Bal']/*[local-name() = 'Tp']/*[local-name() = 'CdOrPrtry']/*[local-name() = 'Cd'][text()='CLBD']/../../.."/>
               </fo:table-body>
 
             </fo:table>
@@ -159,7 +158,7 @@
 
           <fo:block padding-top="3mm" font-size="9pt" font-family="sans-serif">
             <xsl:choose>
-              <xsl:when test="count(/camt:Document/camt:BkToCstmrStmt/camt:Stmt/camt:Ntry) = 0">
+              <xsl:when test="count(/*[local-name() = 'Document']/*[local-name() = 'BkToCstmrStmt']/*[local-name() = 'Stmt']/*[local-name() = 'Ntry']) = 0">
                 <fo:block font-style="italic" text-align="center">No entries booked in this period</fo:block>
               </xsl:when>
               <xsl:otherwise>
@@ -191,9 +190,9 @@
                   </fo:table-header>
 
                   <fo:table-body>
-                    <xsl:apply-templates select="/camt:Document/camt:BkToCstmrStmt/camt:Stmt/camt:Ntry"/>
+                    <xsl:apply-templates select="/*[local-name() = 'Document']/*[local-name() = 'BkToCstmrStmt']/*[local-name() = 'Stmt']/*[local-name() = 'Ntry']"/>
                   </fo:table-body>
-        
+
                 </fo:table>
               </xsl:otherwise>
             </xsl:choose>


### PR DESCRIPTION
This applies [this trick](https://www.marklogic.com/blog/namespace-wildcards-in-xpath/) to make the stylesheets work for any CAMT.053 revision. 